### PR TITLE
Allow edit of test uid to assume chosen identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install
 ## Create a backup of the prod Firestore DB.
 
 ```
-npm run backup
+npm run backup-prod
 ```
 
 ## Restore a backup to the test Firestore DB.
@@ -23,5 +23,5 @@ adjust the rules to allow these objects to be created (and delete the existing o
 or... we could figure out a better permissions solution.
 
 ```
-npm run restoreTest
+npm run restore-test
 ```

--- a/edit-test-uid.js
+++ b/edit-test-uid.js
@@ -1,0 +1,42 @@
+import * as firebase from 'firebase';
+import 'firebase/firestore';
+
+async function main() {
+    const args = process.argv;
+
+    if (args.length !== 7) {
+        throw Error('Usage is "npm run edit-test-uid memberUsername memberPublicPin newUid, e.g. mark.ulrich 2777 vJle6l4K3jdEBk5CvZK4RYyxpFI2"');
+    }
+
+    const memberId = args[4] + '$' + args[5];
+    const newUid = args[6];
+    const config = require('./firebase.test.config.json');
+
+    const changeMsg = `member ID ${memberId} to uid ${newUid} in ${config.projectId}`;
+
+    console.log(`Going to change ${changeMsg}`);
+
+    const app = firebase.initializeApp(config);
+    const db = app.firestore();
+    const numEdits = await db.runTransaction(async tx => {
+        const membersRef = db.collection('members');
+        const opsRef = db.collection('operations');
+        const origMember = await membersRef.where('mid', '==', memberId).get();
+        const numOrig = origMember.docs.length;
+        if (numOrig !== 1) {
+            throw Error(`Found ${numOrig} members with mid of ${memberId}, but expected exactly 1`);
+        }
+        const ops_created_by_orig = await opsRef.where('creator_mid', '==', memberId).get();
+        const ops_to_orig = await opsRef.where('data.to_mid', '==', memberId).get();
+        tx.set(membersRef.doc(newUid), {...origMember.docs[0].data(), ...{uid: newUid}});
+        tx.delete(membersRef.doc(origMember.docs[0].id));
+        await Promise.all(ops_created_by_orig.docs.map(d => tx.update(opsRef.doc(d.id), {creator_uid: newUid})));
+        await Promise.all(ops_to_orig.docs.map(d => tx.update(opsRef.doc(d.id), {'data.to_uid': newUid})));
+        return 1 + ops_created_by_orig.docs.length + ops_to_orig.docs.length;
+    });
+
+    console.log(`Set ${changeMsg} in ${numEdits} places`);
+    process.exit();
+}
+
+main();

--- a/edit-test-uid.js
+++ b/edit-test-uid.js
@@ -1,3 +1,16 @@
+/**
+ * Use this script to change the uid associated with a given member id.
+ *
+ * For example, could do:
+ * npm run edit-test-uid mark.ulrich 2777 vJle6l4K3jdEBk5CvZK4RYyxpFI2
+ *
+ * to make all member and operations documents associated with mark.ulrich$2777 to have
+ * uid vJle6l4K3jdEBk5CvZK4RYyxpFI2. This is useful because the firebase auth UIDs are
+ * different in prod and test, so after logging in on test you can see your uid in
+ * the firebase authentication tab and then run this script to associate that test uid
+ * with a given member id, so then you can log in as that member and view all
+ * public data for debugging and development purposes.
+ */
 import * as firebase from 'firebase';
 import 'firebase/firestore';
 
@@ -10,7 +23,7 @@ async function main() {
 
     const memberId = args[4] + '$' + args[5];
     const newUid = args[6];
-    const config = require('./firebase.test.config.json');
+    const config = require('./firebase.prod.config.json');
 
     const changeMsg = `member ID ${memberId} to uid ${newUid} in ${config.projectId}`;
 

--- a/package.json
+++ b/package.json
@@ -3331,7 +3331,8 @@
     "babel-preset-stage-2": "^6.24.1"
   },
   "scripts": {
-    "backup": "babel-node backup.js --presets es2015,stage-2",
-    "restoreTest": "babel-node restore.js --presets es2015,stage-2"
+    "backup-prod": "babel-node backup.js --presets es2015,stage-2",
+    "edit-test-uid": "babel-node edit-test-uid.js --presets es2015,stage-2",
+    "restore-test": "babel-node restore.js --presets es2015,stage-2"
   }
 }


### PR DESCRIPTION
Now can run a command like `npm run edit-test-uid mark.ulrich 2777 UID` where UID is associated with your email in the test db and it will let you become `mark.ulrich$2777`.